### PR TITLE
Fix proxy support in check

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,8 +70,15 @@ BinWrapper.prototype.check = function (cmd) {
 
     var dl = Object.getOwnPropertyNames(file).length !== 0 ? [].concat(url, file) : url;
 
+     var proxy = process.env.http_proxy ||
+        process.env.HTTP_PROXY ||
+        process.env.https_proxy ||
+        process.env.HTTPS_PROXY ||
+        null;
+
     download(dl, this.dest, {
-        mode: '0755'
+        mode: '0755',
+        proxy: proxy
     }).on('close', function () {
         return self._test(path.join(self.dest, self.bin), cmd);
     });


### PR DESCRIPTION
Hi, 

I saw you added proxy support in latest 0.2.1 version. I found out it was not used in BinWrapper.prototype.check 

Adding this has solved the problem for now, but maybe it could be  better if we put the env variables reading in download library.

Any thoughts about this? 

Thank you
