### PR TITLE
Fixes #23. Existing binaries are correctly executed when using .run().

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,11 @@ BinWrapper.prototype._path = function (cb) {
             }
 
             files = files.filter(function (file) {
-                return file.path.indexOf(which.sync(bin)) === -1;
+                try {
+                    return file.path.indexOf(which.sync(bin)) === -1;
+                } catch(e) {
+                    return true;
+                }
             });
 
             if (!files.length) {

--- a/test.js
+++ b/test.js
@@ -46,6 +46,40 @@ test('set which file to use as the binary', function (t) {
     t.assert(bin._use === 'gifsicle');
 });
 
+test('can use existing binary', function(t) {
+    t.plan(2);
+
+    // add file with same name
+    var fs = require('fs');
+    var mkdir = require('mkdirp');
+
+    var destDir = path.join(__dirname, 'tmp');
+    var destFile = 'test-bin.bat';
+    var destFilePath = path.join(destDir, destFile);
+    mkdir(destDir, function() {
+        var fd = fs.openSync(destFilePath, 'w');
+        fs.close(fd);
+        if (process.platform !== 'win32') {
+            fs.chmodSync(destFilePath, '777');
+        }
+    });
+
+    // use the same path. Shouldn't download anything.
+    var bin = new Bin()
+        .src('https://github.com/imagemin/gifsicle-bin/raw/master/vendor/osx/gifsicle', 'darwin')
+        .src('https://github.com/imagemin/gifsicle-bin/raw/master/vendor/linux/x64/gifsicle', 'linux', 'x64')
+        .src('https://github.com/imagemin/gifsicle-bin/raw/master/vendor/win/x64/gifsicle.exe', 'win32', 'x64')
+        .dest(destDir)
+        .use(destFile)
+        .run([], function(err) {
+            t.assert(!err, err);
+
+            fs.stat(destFilePath, function(err, a) {
+                t.assert(a.size === 0, 'Incorrect size');
+            });
+        });
+});
+
 test('should verify that a binary is working', function (t) {
     t.plan(2);
 
@@ -57,7 +91,7 @@ test('should verify that a binary is working', function (t) {
         .use(process.platform === 'win32' ? 'gifsicle.exe' : 'gifsicle');
 
     bin.run(['--version'], function (err) {
-        t.assert(!err);
+        t.assert(!err, err);
 
         exists(bin.path(), function (exist) {
             t.assert(exist);
@@ -97,7 +131,7 @@ test('should meet the desired version', function (t) {
         .version('>=1.71');
 
     bin.run(['--version'], function (err) {
-        t.assert(!err);
+        t.assert(!err, err);
 
         exists(bin.path(), function (exist) {
             t.assert(exist);


### PR DESCRIPTION
These tests don't work in Windows because bin-check doesn't work in Windows.
