### PR TITLE
Use binary destination set in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bin-version-check": "^2.1.0",
     "download": "^3.3.0",
     "download-status": "^2.0.0",
+    "findup-sync": "^0.2.1",
     "globby": "^1.0.0",
     "is-path-global": "^1.0.0",
     "lnfs": "^1.0.0",


### PR DESCRIPTION
Currently, this will probably break if `.use()` is something like `path/bin`, and if it differs from the binary name in package.json, e.g:

``` js
.use('asd.exe');
```

``` json
{
  "bin": {
    "asd": "bin/asd"
  }
}
```

Fixes #31.
