### PR TITLE
Use lazy-req to require external modules lazily

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var binCheck = require('bin-check');
-var binVersionCheck = require('bin-version-check');
-var Download = require('download');
 var fs = require('fs');
-var osFilterObj = require('os-filter-obj');
+var lazyReq = require('lazy-req')(require);
 var path = require('path');
+
+var binCheck = lazyReq('bin-check');
+var binVersionCheck = lazyReq('bin-version-check');
+var Download = lazyReq('download');
+var osFilterObj = lazyReq('os-filter-obj');
 
 /**
  * Initialize a new `BinWrapper`
@@ -143,7 +145,7 @@ BinWrapper.prototype.run = function (cmd, cb) {
  */
 
 BinWrapper.prototype.runCheck = function (cmd, cb) {
-	binCheck(this.path(), cmd, function (err, works) {
+	binCheck()(this.path(), cmd, function (err, works) {
 		if (err) {
 			cb(err);
 			return;
@@ -155,7 +157,7 @@ BinWrapper.prototype.runCheck = function (cmd, cb) {
 		}
 
 		if (this.version()) {
-			return binVersionCheck(this.path(), this.version(), cb);
+			return binVersionCheck()(this.path(), this.version(), cb);
 		}
 
 		cb();
@@ -193,8 +195,8 @@ BinWrapper.prototype.findExisting = function (cb) {
  */
 
 BinWrapper.prototype.download = function (cb) {
-	var files = osFilterObj(this.src());
-	var download = new Download({
+	var files = osFilterObj()(this.src());
+	var download = new Download()({
 		extract: true,
 		mode: '755',
 		strip: this.opts.strip

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bin-version-check": "^2.1.0",
     "download": "^4.0.0",
     "each-async": "^1.1.1",
+    "lazy-req": "^1.0.0",
     "os-filter-obj": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/imagemin/cwebp-bin/pull/6#issuecomment-71548865

> Yeah, I agree something needs to be fixed too. But I'd rather fix it in bin-wrapper if we can.

I fixed the problem by using [lazy-req](https://github.com/sindresorhus/lazy-req) to load modules lazily.

# Benchmark

## Script

```js
require('time-require');
require('optipng-bin'); // Current `master` 49fa6b116b4dfb27e4579b13ce81bdd90da5ff3e
```

## Result

### With bin-wrapper v3.0.0

```
Start time: (2015-03-16 15:48:43 UTC) [treshold=1%]
 #  module                           time  %
 1  bin-version-ch...eck/index.js)   70ms  ▇ 1%
 2  ./lib/_stream_..._readable.js)  121ms  ▇ 2%
 3  readable-strea.../readable.js)  144ms  ▇ 2%
 4  duplexer2 (nod...er2/index.js)  153ms  ▇ 2%
 5  ./_stream_dupl...am_duplex.js)   76ms  ▇ 1%
 6  ./lib/_stream_...transform.js)   78ms  ▇ 1%
 7  readable-strea...transform.js)   88ms  ▇ 1%
 8  through2 (node.../through2.js)  100ms  ▇ 2%
 9  stream-combine...er2/index.js)  264ms  ▇▇ 4%
10  ./lib/_stream_..._readable.js)  121ms  ▇ 2%
11  readable-strea.../readable.js)  219ms  ▇▇ 4%
12  concat-stream...eam/index.js)   234ms  ▇▇ 4%
13  vinyl (node_mo...nyl/index.js)  106ms  ▇ 2%
14  buffer-to-viny...nyl/index.js)  194ms  ▇ 3%
15  glob (node_mod...glob/glob.js)  146ms  ▇ 2%
16  glob-stream (n...eam/index.js)  229ms  ▇▇ 4%
17  ./getContents...nts/index.js)    73ms  ▇ 1%
18  ./lib/src (nod...src/index.js)  359ms  ▇▇ 6%
19  glob (node_mod...glob/glob.js)   81ms  ▇ 1%
20  globule (node_...b/globule.js)  153ms  ▇ 2%
21  gaze (node_mod.../lib/gaze.js)  215ms  ▇▇ 3%
22  glob-watcher (...her/index.js)  240ms  ▇▇ 4%
23  vinyl-fs (node...-fs/index.js)  653ms  ▇▇▇▇ 10%
24  ./lib/_stream_...am_duplex.js)   93ms  ▇ 1%
25  readable-strea...am/duplex.js)   97ms  ▇ 2%
26  bl (node_modul...les/bl/bl.js)  114ms  ▇ 2%
27  ./extract (nod...m/extract.js)  185ms  ▇ 3%
28  tar-stream (no...eam/index.js)  227ms  ▇▇ 4%
29  decompress-tar...tar/index.js)  273ms  ▇▇ 4%
30  tar-stream (no...eam/index.js)   68ms  ▇ 1%
31  decompress-tar...bz2/index.js)  119ms  ▇ 2%
32  strip-dirs (no...irs/index.js)   73ms  ▇ 1%
33  ./lib/_stream_...am_duplex.js)  133ms  ▇ 2%
34  readable-strea...am/duplex.js)  136ms  ▇ 2%
35  bl (node_modul...les/bl/bl.js)  140ms  ▇ 2%
36  readable-strea.../readable.js)  103ms  ▇ 2%
37  ./extract (nod...m/extract.js)  276ms  ▇▇ 4%
38  wrappy (node_m...py/wrappy.js)   82ms  ▇ 1%
39  once (node_mod...once/once.js)  198ms  ▇ 3%
40  end-of-stream...eam/index.js)   201ms  ▇ 3%
41  ./pack (node_m...ream/pack.js)  316ms  ▇▇ 5%
42  tar-stream (no...eam/index.js)  647ms  ▇▇▇▇ 10%
43  decompress-tar...rgz/index.js)  742ms  ▇▇▇▇ 12%
44  is-zip (node_m...zip/index.js)   83ms  ▇ 1%
45  is-absolute (n...ute/index.js)  160ms  ▇ 3%
46  strip-dirs (no...irs/index.js)  191ms  ▇ 3%
47  pend (node_mod...end/index.js)  110ms  ▇ 2%
48  fd-slicer (nod...cer/index.js)  196ms  ▇ 3%
49  yauzl (node_mo...uzl/index.js)  257ms  ▇▇ 4%
50  decompress-unz...zip/index.js)  745ms  ▇▇▇▇ 12%
51  decompress (no...ess/index.js)   2.8s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 44%
52  replace-ext (n...ext/index.js)   63ms  ▇ 1%
53  ansi-styles (n...les/index.js)   86ms  ▇ 1%
54  strip-ansi (no...nsi/index.js)  113ms  ▇ 2%
55  has-ansi (node...nsi/index.js)  112ms  ▇ 2%
56  chalk (node_mo...alk/index.js)  408ms  ▇▇ 7%
57  lodash.escape...ape/index.js)    70ms  ▇ 1%
58  lodash.keys (n...eys/index.js)  188ms  ▇ 3%
59  lodash.templat...ngs/index.js)   91ms  ▇ 1%
60  lodash.templat...ate/index.js)  505ms  ▇▇▇ 8%
61  ./lib/template.../template.js)  537ms  ▇▇▇ 9%
62  ./lib/noop (no.../lib/noop.js)   72ms  ▇ 1%
63  ./lib/isStream.../isStream.js)  159ms  ▇ 3%
64  ./lib/isBuffer.../isBuffer.js)  161ms  ▇ 3%
65  isarray (node_...ray/index.js)   69ms  ▇ 1%
66  ./lib/_stream_..._readable.js)  177ms  ▇ 3%
67  ./lib/_stream_...ssthrough.js)   65ms  ▇ 1%
68  readable-strea.../readable.js)  395ms  ▇▇ 6%
69  duplexer2 (nod...er2/index.js)  415ms  ▇▇ 7%
70  multipipe (nod...ipe/index.js)  425ms  ▇▇▇ 7%
71  ./lib/combine...b/combine.js)   441ms  ▇▇▇ 7%
72  ./lib/buffer (...ib/buffer.js)   91ms  ▇ 1%
73  ./lib/PluginEr...uginError.js)   76ms  ▇ 1%
74  gulp-util (nod...til/index.js)   2.2s  ▇▇▇▇▇▇▇▇▇▇▇ 35%
75  gulp-decompres...ess/index.js)     5s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 80%
76  ./lib/_stream_..._readable.js)  122ms  ▇ 2%
77  readable-strea.../readable.js)  231ms  ▇▇ 4%
78  duplexify (nod...ify/index.js)  268ms  ▇▇ 4%
79  got (node_modu...got/index.js)  356ms  ▇▇ 6%
80  download (node...oad/index.js)   5.9s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 95%
81  ./sync.js (nod...glob/sync.js)   66ms  ▇ 1%
82  glob (node_mod...glob/glob.js)  167ms  ▇ 3%
83  globby (node_m...bby/index.js)  205ms  ▇ 3%
84  bin-wrapper (n...per/index.js)   6.2s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 100%
85  ./lib (lib/index.js)             6.2s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 100%
86  ./ (index.js)                    6.2s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 100%
Total require(): 664
Total time: 6.2s
```

### With *lazy-req* version of bin-wrapper

```
Start time: (2015-03-16 16:14:09 UTC) [treshold=1%]
 #  module                          time  %
 1  text-table (no...ble/index.js)   1ms  ▇▇▇ 7%
 2  date-time (nod...ime/index.js)   1ms  ▇▇▇ 7%
 3  pretty-ms (nod...-ms/index.js)   1ms  ▇▇▇ 7%
 4  ansi-styles (n...si-styles.js)   1ms  ▇▇▇ 7%
 5  strip-ansi (no...nsi/index.js)   1ms  ▇▇▇ 7%
 6  chalk (node_mo...alk/index.js)   4ms  ▇▇▇▇▇▇▇▇▇ 29%
 7  bin-wrapper (n...per/index.js)   2ms  ▇▇▇▇▇ 14%
 8  ../package.jso...package.json)   1ms  ▇▇▇ 7%
 9  ./lib (lib/index.js)             4ms  ▇▇▇▇▇▇▇▇▇ 29%
10  ./ (index.js)                    4ms  ▇▇▇▇▇▇▇▇▇ 29%
Total require(): 16
Total time: 14ms
```

Over 400 times faster than ever.
