### PR TITLE
Fix critical error when space in bin path

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,8 @@ BinWrapper.prototype.runCheck = function (cmd, cb) {
 		}
 
 		if (this.version()) {
-			binVersionCheck()(this.path(), this.version(), cb);
+			var escapedPath = this.path().replace(/ /g, '\\ ');
+			binVersionCheck()(escapedPath, this.version(), cb);
 			return;
 		}
 


### PR DESCRIPTION
The bin-version-check module delegates version extraction to the bin-version module: https://github.com/sindresorhus/bin-version-check/blob/master/index.js#L16

The bin-version module extracts the bin version with childProcess.exec(bin + ' --version', ...): https://github.com/sindresorhus/bin-version/blob/master/index.js#L6

childProcess.exec expects its first argument to be "The command to run, with space-separated arguments": https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

Consequently, before my fix, if a space is present in the path to the bin, everything after the first space is interpreted as arguments. And the bin correspond to the first part of the path (before the first space), which is NOT ok.
