### PR TITLE
Chore: minimum required `lazy-req` version is now `^2.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bin-version-check": "^2.1.0",
     "download": "^4.0.0",
     "each-async": "^1.1.1",
-    "lazy-req": "^1.0.0",
+    "lazy-req": "^2.0.0",
     "os-filter-obj": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `lazy-req` to latest version.