### PR TITLE
Update most dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ module.exports = class BinWrapper {
 	 * @api private
 	 */
 	runCheck(cmd, cb) {
-		binCheck()(this.path(), cmd, (err, works) => {
+		binCheck(this.path(), cmd, (err, works) => {
 			if (err) {
 				cb(err);
 				return;
@@ -150,7 +150,7 @@ module.exports = class BinWrapper {
 			}
 
 			if (this.version()) {
-				binVersionCheck()(this.path(), this.version(), cb);
+				binVersionCheck(this.path(), this.version(), cb);
 				return;
 			}
 
@@ -187,8 +187,8 @@ module.exports = class BinWrapper {
 	 * @api private
 	 */
 	download(cb) {
-		const files = osFilterObj()(this.src() || []);
-		const download = new Download()({
+		const files = osFilterObj(this.src() || []);
+		const download = new Download({
 			extract: true,
 			mode: '755',
 			strip: this.options.strip

--- a/index.js
+++ b/index.js
@@ -145,12 +145,12 @@ module.exports = class BinWrapper {
 				}
 
 				if (this.version()) {
-					binVersionCheck(this.path(), this.version(), cb);
-					return;
+					return binVersionCheck(this.path(), this.version());
 				}
 
-				cb();
+				return Promise.resolve();
 			})
+			.then(() => cb())
 			.catch(err => cb(err));
 	}
 

--- a/index.js
+++ b/index.js
@@ -138,24 +138,20 @@ module.exports = class BinWrapper {
 	 * @api private
 	 */
 	runCheck(cmd, cb) {
-		binCheck(this.path(), cmd, (err, works) => {
-			if (err) {
-				cb(err);
-				return;
-			}
+		binCheck(this.path(), cmd)
+			.then(works => {
+				if (!works) {
+					throw new Error(`The \`${this.path()}\` binary doesn't seem to work correctly`);
+				}
 
-			if (!works) {
-				cb(new Error(`The \`${this.path()}\` binary doesn't seem to work correctly`));
-				return;
-			}
+				if (this.version()) {
+					binVersionCheck(this.path(), this.version(), cb);
+					return;
+				}
 
-			if (this.version()) {
-				binVersionCheck(this.path(), this.version(), cb);
-				return;
-			}
-
-			cb();
-		});
+				cb();
+			})
+			.catch(err => cb(err));
 	}
 
 	/**

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ module.exports = class BinWrapper {
 	 * @api private
 	 */
 	download(cb) {
-		const files = osFilterObj()(this.src());
+		const files = osFilterObj()(this.src() || []);
 		const download = new Download()({
 			extract: true,
 			mode: '755',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"bin-version-check": "^2.1.0",
 		"download": "^4.0.0",
 		"import-lazy": "^2.1.0",
-		"os-filter-obj": "^1.0.0"
+		"os-filter-obj": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"bin-check": "^4.1.0",
-		"bin-version-check": "^2.1.0",
+		"bin-version-check": "^3.0.0",
 		"download": "^4.0.0",
 		"import-lazy": "^3.1.0",
 		"os-filter-obj": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"wrapper"
 	],
 	"dependencies": {
-		"bin-check": "^2.0.0",
+		"bin-check": "^4.1.0",
 		"bin-version-check": "^2.1.0",
 		"download": "^4.0.0",
 		"import-lazy": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"bin-check": "^2.0.0",
 		"bin-version-check": "^2.1.0",
 		"download": "^4.0.0",
-		"import-lazy": "^2.1.0",
+		"import-lazy": "^3.1.0",
 		"os-filter-obj": "^2.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The exception being download, I'll open a separate PR for it once this one is merged. The unit tests are fighting me.

As an aside, now that the dependencies are all Promise-based, what do you think about changing the API of `bin-wrapper` to be Promise-based?