### PR TITLE
Set dowloaded files to be executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	},
 	"devDependencies": {
 		"ava": "*",
+		"executable": "^4.1.1",
 		"nock": "^9.4.2",
 		"path-exists": "^3.0.0",
 		"rimraf": "^2.6.2",


### PR DESCRIPTION
This matches the behavior of bin-wrapper 3.0

Fixes #67

Contains #68 to make the build pass