### PR TITLE
Ability to specify base url

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,8 +174,6 @@ module.exports = class BinWrapper {
 			if (this.version()) {
 				return binVersionCheck(this.path(), this.version());
 			}
-
-			return Promise.resolve();
 		});
 	}
 
@@ -221,6 +219,7 @@ module.exports = class BinWrapper {
 					return item.map(file => file.path);
 				}
 
+				// eslint-disable-next-line node/no-deprecated-api
 				const parsedUrl = url.parse(files[index].url);
 				const parsedPath = path.parse(parsedUrl.pathname);
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava",
+		"ba": "node --version"
 	},
 	"files": [
 		"index.js"
@@ -33,7 +34,7 @@
 		"pify": "^4.0.1"
 	},
 	"devDependencies": {
-		"ava": "*",
+		"ava": "1.4.1",
 		"executable": "^4.1.1",
 		"nock": "^10.0.2",
 		"path-exists": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,57 @@ Default: `1`
 
 Strip a number of leading paths from file names on extraction.
 
+### .baseUrl(baseUrl)
+
+Accepts a base URL that is prepended to everything added as a src using [.src](#.src(url, [os], [arch])).
+
+#### baseUrl
+
+Type: `string`
+
+Accepts a URL pointing to use as the base URL.
+
+#### Usage
+
+```js
+const BinWrapper = require('bin-wrapper');
+
+const bin = new BinWrapper()
+	.baseUrl('https://github.com/imagemin/gifsicle-bin/raw/master/vendor')
+	.src(`/linux/x64/gifsicle`, 'linux', 'x64')
+	.dest(path.join('vendor'))
+	.use(process.platform === 'win32' ? 'gifsicle.exe' : 'gifsicle')
+```
+
+### .baseUrlOverrideEnvName(envName)
+
+ Accepts an enviroment variable name to look for. When set the value of this enviroment varibale overrides the value set using [.baseUrl](#.baseUrl(baseUrl)).
+
+#### envName
+
+Type: `string`
+
+Accepts a enviroment variable name.
+
+#### Usage
+
+The below will download the binary from `http://example.com/private/mirror/linux/x64/gifsicle`
+
+```sh
+export GIFSICLE_BIN__MIRROR="http://example.com/private/mirror
+```
+
+```js
+const BinWrapper = require('bin-wrapper');
+
+const bin = new BinWrapper()
+	.baseUrl('https://github.com/imagemin/gifsicle-bin/raw/master/vendor')
+	.baseUrlOverrideEnvName('GIFSICLE_BIN__MIRROR')
+	.src(`/linux/x64/gifsicle`, 'linux', 'x64')
+	.dest(path.join('vendor'))
+	.use(process.platform === 'win32' ? 'gifsicle.exe' : 'gifsicle')
+```
+
 ### .src(url, [os], [arch])
 
 Adds a source to download.


### PR DESCRIPTION
Adds the ability to specify a base url to use when performing configuration. 

This allows you to follow the following pattern:

```js
const BinWrapper = require('bin-wrapper');

const bin = new BinWrapper()
	.baseUrl('https://github.com/imagemin/gifsicle-bin/raw/master/vendor')
	.src(`/linux/x64/gifsicle`, 'linux', 'x64')
	.src(`/linux/x86/gifsicle`, 'linux', 'x86')
	.dest(path.join('vendor'))
	.use(process.platform === 'win32' ? 'gifsicle.exe' : 'gifsicle')
```


Additionally added the ability for developers to allow for this base url to be easily configured when this library is used to expose a binary. 

For example, in the below example when the `GIFSICLE_BIN__MIRROR` env var is set, this will be used as the base location from which to perform the download:

```js
const BinWrapper = require('bin-wrapper');

const bin = new BinWrapper()
	.baseUrl('https://github.com/imagemin/gifsicle-bin/raw/master/vendor')
        .baseUrlOverrideEnvName('GIFSICLE_BIN__MIRROR')
	.src(`/linux/x64/gifsicle`, 'linux', 'x64')
	.dest(path.join('vendor'))
	.use(process.platform === 'win32' ? 'gifsicle.exe' : 'gifsicle')
```

This allows for developers to easily add support for configuring the binary download location, this allows developers to easily support 3rd party binary mirrors and cases where due to security considerations downloading from an external source can not be considered.