### PR TITLE
feat: Support for local files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bin-wrapper",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"description": "Binary wrapper that makes your programs seamlessly available as local dependencies",
 	"license": "MIT",
 	"repository": "kevva/bin-wrapper",
@@ -9,6 +9,18 @@
 		"email": "kevinmartensson@gmail.com",
 		"url": "https://github.com/kevva"
 	},
+	"contributors": [
+		{
+			"name": "Kevin Mårtensson",
+			"email": "kevinmartensson@gmail.com",
+			"url": "https://github.com/kevva"
+		},
+		{
+			"name": "Philip van Heemstra",
+			"email": "vanheemstra@gmail.com",
+			"url": "https://github.com/vheemstra"
+		}
+	],
 	"engines": {
 		"node": ">=6"
 	},

--- a/package.json
+++ b/package.json
@@ -9,18 +9,6 @@
 		"email": "kevinmartensson@gmail.com",
 		"url": "https://github.com/kevva"
 	},
-	"contributors": [
-		{
-			"name": "Kevin Mårtensson",
-			"email": "kevinmartensson@gmail.com",
-			"url": "https://github.com/kevva"
-		},
-		{
-			"name": "Philip van Heemstra",
-			"email": "vanheemstra@gmail.com",
-			"url": "https://github.com/vheemstra"
-		}
-	],
 	"engines": {
 		"node": ">=6"
 	},

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,9 @@ const BinWrapper = require('bin-wrapper');
 
 const base = 'https://github.com/imagemin/gifsicle-bin/raw/master/vendor';
 const bin = new BinWrapper()
+	.localSrc(`vendor/macos/gifsicle`, 'darwin')
+	.localSrc(`vendor/linux/x64/gifsicle`, 'linux', 'x64')
+	.localSrc(`vendor/win/x64/gifsicle.exe`, 'win32', 'x64')
 	.src(`${base}/macos/gifsicle`, 'darwin')
 	.src(`${base}/linux/x64/gifsicle`, 'linux', 'x64')
 	.src(`${base}/win/x64/gifsicle.exe`, 'win32', 'x64')
@@ -84,13 +87,23 @@ Type: `string`
 
 Tie the source to a specific arch.
 
+### .localSrc(filepath, [os], [arch])
+
+Same as `.src()`, but adds a local source to copy, before trying any downloads.
+
+#### filepath
+
+Type: `string`
+
+Accepts a filepath pointing to a local file.
+
 ### .dest(destination)
 
 #### destination
 
 Type: `string`
 
-Accepts a path which the files will be downloaded to.
+Accepts a path which the files will be copied/downloaded to.
 
 ### .use(binary)
 


### PR DESCRIPTION
### Support for copying local binaries before trying the downloads.

> Works the same as `.src()`, except url is a local filepath.
> Bin-wrapper now tries the `localSrc`s first (copying them in place when found) and falls back to downloading `src`s on fail.

#### Reason
Downloading binaries slows down CI scripts significantly and a lot of the packages using `bin-wrapper` ship with binaries which have already been downloaded and can be used.

#### Changes
* Added local file support
* Updated docs